### PR TITLE
Bugfix/fix dtype obs space

### DIFF
--- a/deep_sea_treasure/__version__.py
+++ b/deep_sea_treasure/__version__.py
@@ -2,5 +2,5 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-VERSION: str = "2.0.0"
+VERSION: str = "2.0.1"
 COMMIT_HASH: str = ""

--- a/deep_sea_treasure/deep_sea_treasure_v0.py
+++ b/deep_sea_treasure/deep_sea_treasure_v0.py
@@ -88,7 +88,7 @@ class DeepSeaTreasureV0(gym.Env): #type: ignore[misc]
 		# Observation is a 2 x (N + 1) matrix, if the environment has size N
 		# First column is the submarine's x (0) and y (1) velocity
 		# Next N columns represent the relative coordinates from the submarine to each treasure
-		self.observation_space = gym.spaces.Box(low=float("-inf"), high=float("+inf"), shape=(2, 1 + len(env_config["treasure_values"])))
+		self.observation_space = gym.spaces.Box(low=np.iinfo(np.int32).min, high=np.iinfo(np.int32).max, shape=(2, 1 + len(env_config["treasure_values"])), dtype=np.int32)
 
 		# Dictionary
 		# This dictionary maps an (x, y) coordinate pair to the associated treasure

--- a/tests/test_deep_sea_treasure.py
+++ b/tests/test_deep_sea_treasure.py
@@ -180,6 +180,7 @@ class DeepSeaTreasureV0Test(unittest.TestCase):
 		actual_observation: np.ndarray = dst.reset()
 
 		self.assertEqual(expected_observation.shape, actual_observation.shape)
+		self.assertEqual(dst.observation_space.dtype, actual_observation.dtype)
 
 		for (exp, act) in zip(np.nditer(expected_observation), np.nditer(actual_observation)):
 			self.assertEqual(exp, act)


### PR DESCRIPTION
Moves obs space to int32 type, adhering the np types used in the observations.