### PR TITLE
Removed gemnasium dependency checking

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,6 @@ image: "gitlab.ilabt.imec.be:4567/team-peter-hellinckx/ci/python-ci:python-37"
 
 
 include:
-  - template: Dependency-Scanning.gitlab-ci.yml
   - template: Security/SAST.gitlab-ci.yml
   - template: Security/Secret-Detection.gitlab-ci.yml
   - template: Security/License-Scanning.gitlab-ci.yml


### PR DESCRIPTION
Gemnasium doesn't seem to work with Python 3.8 yet. Removed it for now to stop the CI pipeline from being marked as failed.